### PR TITLE
Fix/env and ops issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 **/libmicroros/
 rtthread_toolchain.cmake
 user.meta
+examples/**/*.o
+src/*.o

--- a/builder/microros_utils/repositories.py
+++ b/builder/microros_utils/repositories.py
@@ -10,7 +10,7 @@ from .utils import run_cmd
 
 def get_country_code():
     try:
-        response = requests.get('https://ipinfo.io')
+        response = requests.get('https://ipinfo.io', timeout=5)
         data = response.json()
         return data['country']
     except Exception as e:

--- a/builder/microros_utils/utils.py
+++ b/builder/microros_utils/utils.py
@@ -44,27 +44,26 @@ class EnvironmentHandler:
         self.modified_env = os.environ.copy()
 
     def find_and_set_python3(self):
-        path_sep = ";" if platform.system() == "Windows" else ":"
-        path = self.modified_env['PATH'].split(path_sep)
-        
-        # Use case-insensitive search for 'python3' in path
-        possible_python_path = [x for x in path if re.search(r'python3', x, re.IGNORECASE) and "Scripts" not in x]
-        print("possible_python_path:",possible_python_path)
-
-        if len(possible_python_path) >= 1:
-            python_script_path = [x for x in path if re.search(r'python3', x, re.IGNORECASE) and "Scripts" in x]
-            # Prepend paths to PATH variable
-            path.insert(0, possible_python_path[0])
-            if python_script_path:
-                path.insert(0, python_script_path[0])
-            self.set_environment_variable('PATH', path_sep.join(path))
-            
-            # Check that pip is installed
-            python_cmd = 'python3' if platform.system() != 'nt' else 'py -3'
-            run_cmd(f'{python_cmd} -m ensurepip', env=self.modified_env, capture_output=True)
-
-            return True
+        path = self.modified_env.get('PATH', ' ').split(os.pathsep)
+        if (os.name == 'nt'):
+            possible_python_path = [x for x in path if "Python3" in x and "Scripts" not in x]
+            print("possible_python_path:",possible_python_path)
+            if len(possible_python_path) >= 1:
+                python_script_path = [x for x in path if "Python3" in x and "Scripts" in x]
+                path.insert(0, possible_python_path[0])
+                if python_script_path:
+                    path.insert(0, python_script_path[0])
+                self.set_environment_variable('PATH', os.pathsep.join(path))
+                run_cmd('py -3 -m ensurepip', env=self.modified_env, capture_output=True)
+                return True
+            else:
+                return False
         else:
+            for child_path in path:
+                if 'bin' in child_path.lower() and \
+                    os.path.exists(os.path.join(child_path, 'python3')):
+                    run_cmd('python3 -m ensurepip', env=self.modified_env, capture_output=True)
+                    return True
             return False
 
     def install_python_dependencies(self, deps):

--- a/examples/rclc_examples/microros_sub.c
+++ b/examples/rclc_examples/microros_sub.c
@@ -32,7 +32,9 @@
 
 rcl_subscription_t subscriber;
 std_msgs__msg__String msg;
-char test_array[ARRAY_LEN];
+
+char remote_addr[20] = {0};
+char remote_port[10]= {0};
 
 void subscription_callback(const void * msgin)
 {
@@ -42,7 +44,6 @@ void subscription_callback(const void * msgin)
 
 static void microros_sub_string_thread_entry(void *parameter)
 {
-    memset(test_array,'z',ARRAY_LEN);
 
     rcl_allocator_t allocator = rcl_get_default_allocator();
     rclc_support_t support;
@@ -80,6 +81,23 @@ static void microros_sub_string_thread_entry(void *parameter)
     RCCHECK(rcl_node_fini(&node));
 }
 
+static void set_transports(char *addr, char *port)
+{
+    rt_strncpy(remote_addr, addr, rt_strlen(addr));
+    rt_strncpy(remote_port, port, rt_strlen(port));
+    remote_addr[rt_strlen(addr)] = '\0';
+    remote_port[rt_strlen(port)] = '\0';
+}
+static char *get_remote_addr()
+{
+    return remote_addr;
+}
+
+static int get_remote_port()
+{
+    return (uint32_t)atoi(remote_port);
+}
+
 static void microros_sub_string(int argc, char* argv[])
 {
 #if defined(PKG_MICRO_ROS_USE_SERIAL)
@@ -95,13 +113,14 @@ static void microros_sub_string(int argc, char* argv[])
             LOG_E("Please refer to the parameters correctly!");
             LOG_E("Or you should define the 'MICRO_ROS_UDP_IP' and 'MICRO_ROS_UDP_PORT' variables in the rtconfig.h file");
         }
-        set_microros_udp_transports(MICRO_ROS_UDP_IP, MICRO_ROS_UDP_PORT);
+        set_microros_udp_transports(MICRO_ROS_UDP_IP, (uint32_t)atoi(MICRO_ROS_UDP_PORT));
         LOG_I("The current proxy IP address is [%s] | Agent port is [%s].", MICRO_ROS_UDP_IP, MICRO_ROS_UDP_PORT);
      }
      else
      {
-        set_microros_udp_transports(argv[1], (atoi)(argv[2]));
-        LOG_I("The current proxy IP address is [%s] | Agent port is [%s].",argv[1], argv[2]);
+        set_transports(argv[1], argv[2]);
+        set_microros_udp_transports(get_remote_addr(), get_remote_port());
+        LOG_I("The current proxy IP address is [%s] | Agent port is [%s].",remote_addr, remote_port);
      }
 
 #elif defined(PKG_MICRO_ROS_USE_TCP)
@@ -123,7 +142,7 @@ static void microros_sub_string(int argc, char* argv[])
      }
 #endif
 
-    rt_thread_t thread = rt_thread_create("mr_substring", microros_sub_string_thread_entry, RT_NULL, 2048, 25, 10);
+    rt_thread_t thread = rt_thread_create("mr_substring", microros_sub_string_thread_entry, RT_NULL, 4096, 10, 10);
     if(thread != RT_NULL)
     {
         rt_thread_startup(thread);


### PR DESCRIPTION
主要修复构建时和运行问题
- 构建时
寻找python3环境问题：在linux平台上会在此处卡住，无法往后运行，所以修改此处判断代码
构建时卡住问题：在不开启vpn情况下，访问ipinfo.io会一直卡住，时间无法确定，因为访问该网站失败，所以增加了超时时间
- 运行时
rclc_support_init返回RMW_RET_ERROR问题：原因是传递的参数port是字符串类型，而是用的是int类型，使用menuconfig生成的宏的值为字符串类型；通过参数传递的argv值作用域只在栈上，若不保存，之后执行时获取的值均为null
线程栈溢出：实际运行下来2k栈不够实用。

潜藏问题（不知道是否需要修复）
- 构建时
clock_gettime导致编译错误：rtt_udp_transport中有clock_gettime接口，发现与rtt系统中的一个接口重名，会导致构建失败，该接口我看仅在rclc_examples/micro_ros_ping_pong.c中使用
Micro-XRCE-DDS-Client下载问题：microros_utils/repositories.py中foxy下Micro-XRCE-DDS-Client采用gitee链接，在开启梯子情况下，无法正常下载，需要更换为github链接，我看作者的仓库中有该项目，尝试了更换，能正常下载，但就是编译会出问题；但rclc已经正常使用，我就没有深究Micro-XRCE-DDS-Client编译问题（我是小白请谅解）
rclc定时器不工作：我在设置发布者是，发现rclc的定时器不工作，我运行rclc_examples/microros_pub.c时也是不工作，目前我新建线程来代替定时器进行发布
